### PR TITLE
Finalize fast-reboot in warmboot finalizer

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -237,7 +237,7 @@ function postStartAction()
             fi
 
             if [[ "$BOOT_TYPE" == "fast" ]]; then
-                $SONIC_DB_CLI STATE_DB SET "FAST_REBOOT|system" "enable"
+                $SONIC_DB_CLI STATE_DB SET "FAST_RESTART_ENABLE_TABLE|system" "enable"
             fi
 
             $SONIC_DB_CLI CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -237,7 +237,7 @@ function postStartAction()
             fi
 
             if [[ "$BOOT_TYPE" == "fast" ]]; then
-                $SONIC_DB_CLI STATE_DB SET "FAST_RESTART_ENABLE_TABLE|system" "enable"
+                $SONIC_DB_CLI STATE_DB HSET "FAST_RESTART_ENABLE_TABLE|system" "enable" "true"
             fi
 
             $SONIC_DB_CLI CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -237,8 +237,7 @@ function postStartAction()
             fi
 
             if [[ "$BOOT_TYPE" == "fast" ]]; then
-                # set the key to expire in 3 minutes
-                $SONIC_DB_CLI STATE_DB SET "FAST_REBOOT|system" "1" "EX" "180"
+                $SONIC_DB_CLI STATE_DB SET "FAST_REBOOT|system" "enable"
             fi
 
             $SONIC_DB_CLI CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"

--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -8,11 +8,11 @@ reboot_type='cold'
 function get_database_reboot_type()
 {
     SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
-    SYSTEM_FAST_START=`sonic-db-cli STATE_DB get "FAST_REBOOT|system"`
+    SYSTEM_FAST_START=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
 
     if [[ x"${SYSTEM_WARM_START}" == x"true" ]]; then
         reboot_type='warm'
-    elif [[ x"${SYSTEM_FAST_START}" == x"1" ]]; then
+    elif [[ x"${SYSTEM_FAST_START}" == x"enable" ]]; then
         reboot_type='fast'
     fi
 }

--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -8,7 +8,7 @@ reboot_type='cold'
 function get_database_reboot_type()
 {
     SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
-    SYSTEM_FAST_START=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    SYSTEM_FAST_START=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
 
     if [[ x"${SYSTEM_WARM_START}" == x"true" ]]; then
         reboot_type='warm'

--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -8,11 +8,11 @@ reboot_type='cold'
 function get_database_reboot_type()
 {
     SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
-    SYSTEM_FAST_START=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
+    SYSTEM_FAST_START=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
 
     if [[ x"${SYSTEM_WARM_START}" == x"true" ]]; then
         reboot_type='warm'
-    elif [[ x"${SYSTEM_FAST_START}" == x"enable" ]]; then
+    elif [[ x"${SYSTEM_FAST_START}" == x"true" ]]; then
         reboot_type='fast'
     fi
 }

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -55,13 +55,11 @@ function check_warm_boot()
 function check_fast_reboot()
 {
     debug "Checking if fast-reboot is enabled..."
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
-    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
+    FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    if [[ x"${FAST_REBOOT}" == x"true" ]]; then
        debug "Fast-reboot is enabled..."
-       FAST_REBOOT='true'
     else
        debug "Fast-reboot is disabled..."
-       FAST_REBOOT='false'
     fi
 }
 
@@ -113,7 +111,7 @@ function finalize_warm_boot()
 function finalize_fast_reboot()
 {
     debug "Finalizing fast-reboot..."
-    sonic-db-cli STATE_DB SET "FAST_RESTART_ENABLE_TABLE|system" "disable" &>/dev/null
+    sonic-db-cli STATE_DB hset "FAST_RESTART_ENABLE_TABLE|system" "enable" "false" &>/dev/null
 }
 
 function stop_control_plane_assistant()
@@ -172,7 +170,7 @@ if [[ -n "${list}" ]]; then
     debug "Some components didn't finish reconcile: ${list} ..."
 fi
 
-if [ ${FAST_REBOOT} == "true" ]; then
+if [ x"${FAST_REBOOT}" == x"true" ]; then
     finalize_fast_reboot
 fi
 finalize_warm_boot

--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -54,10 +54,13 @@ function check_warm_boot()
 
 function check_fast_reboot()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    debug "Checking if fast-reboot is enabled..."
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
     if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
+       debug "Fast-reboot is enabled..."
        FAST_REBOOT='true'
     else
+       debug "Fast-reboot is disabled..."
        FAST_REBOOT='false'
     fi
 }
@@ -110,7 +113,7 @@ function finalize_warm_boot()
 function finalize_fast_reboot()
 {
     debug "Finalizing fast-reboot..."
-    sonic-db-cli STATE_DB SET "FAST_REBOOT|system" "disable" &>/dev/null
+    sonic-db-cli STATE_DB SET "FAST_RESTART_ENABLE_TABLE|system" "disable" &>/dev/null
 }
 
 function stop_control_plane_assistant()

--- a/files/scripts/bgp.sh
+++ b/files/scripts/bgp.sh
@@ -30,8 +30,8 @@ function validate_restore_count()
 
 function check_fast_boot ()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
-    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"

--- a/files/scripts/bgp.sh
+++ b/files/scripts/bgp.sh
@@ -30,7 +30,7 @@ function validate_restore_count()
 
 function check_fast_boot ()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
     if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else

--- a/files/scripts/bgp.sh
+++ b/files/scripts/bgp.sh
@@ -30,7 +30,8 @@ function validate_restore_count()
 
 function check_fast_boot ()
 {
-    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"

--- a/files/scripts/service_mgmt.sh
+++ b/files/scripts/service_mgmt.sh
@@ -19,7 +19,8 @@ function check_warm_boot()
 
 function check_fast_boot ()
 {
-    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"

--- a/files/scripts/service_mgmt.sh
+++ b/files/scripts/service_mgmt.sh
@@ -19,8 +19,8 @@ function check_warm_boot()
 
 function check_fast_boot ()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
-    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"

--- a/files/scripts/service_mgmt.sh
+++ b/files/scripts/service_mgmt.sh
@@ -19,7 +19,7 @@ function check_warm_boot()
 
 function check_fast_boot ()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
     if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -60,8 +60,8 @@ function check_warm_boot()
 
 function check_fast_boot()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
-    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"
@@ -286,7 +286,7 @@ stop() {
     # be restarted.
     if [[ x"$FAST_BOOT" != x"true" ]]; then
         debug "Clearing FAST_RESTART_ENABLE_TABLE flag..."
-        sonic-db-cli STATE_DB SET "FAST_RESTART_ENABLE_TABLE|system" "disable"
+        sonic-db-cli STATE_DB hset "FAST_RESTART_ENABLE_TABLE|system" "enable" "false"
     fi
     # Unlock has to happen before reaching out to peer service
     unlock_service_state_change

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -60,7 +60,8 @@ function check_warm_boot()
 
 function check_fast_boot()
 {
-    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"
@@ -285,7 +286,7 @@ stop() {
     # be restarted.
     if [[ x"$FAST_BOOT" != x"true" ]]; then
         debug "Clearing FAST_REBOOT flag..."
-        clean_up_tables STATE_DB "'FAST_REBOOT*'"
+        sonic-db-cli STATE_DB SET "FAST_REBOOT|system" "disable"
     fi
     # Unlock has to happen before reaching out to peer service
     unlock_service_state_change

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -60,7 +60,7 @@ function check_warm_boot()
 
 function check_fast_boot()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
     if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
@@ -285,8 +285,8 @@ stop() {
     # encountered error, e.g. syncd crashed. And swss needs to
     # be restarted.
     if [[ x"$FAST_BOOT" != x"true" ]]; then
-        debug "Clearing FAST_REBOOT flag..."
-        sonic-db-cli STATE_DB SET "FAST_REBOOT|system" "disable"
+        debug "Clearing FAST_RESTART_ENABLE_TABLE flag..."
+        sonic-db-cli STATE_DB SET "FAST_RESTART_ENABLE_TABLE|system" "disable"
     fi
     # Unlock has to happen before reaching out to peer service
     unlock_service_state_change

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -50,7 +50,8 @@ function check_warm_boot()
 
 function check_fast_boot()
 {
-    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"
@@ -82,7 +83,8 @@ function getBootType()
         ;;
     *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
         # check that the key exists
-        if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+        SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+        if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
             TYPE='fast'
         else
             TYPE='cold'

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -50,7 +50,7 @@ function check_warm_boot()
 
 function check_fast_boot()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
     if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
@@ -83,7 +83,7 @@ function getBootType()
         ;;
     *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
         # check that the key exists
-        SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+        SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
         if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
             TYPE='fast'
         else

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -50,8 +50,8 @@ function check_warm_boot()
 
 function check_fast_boot()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
-    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"
@@ -83,8 +83,8 @@ function getBootType()
         ;;
     *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
         # check that the key exists
-        SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
-        if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
+        SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+        if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
             TYPE='fast'
         else
             TYPE='cold'

--- a/files/scripts/teamd.sh
+++ b/files/scripts/teamd.sh
@@ -32,7 +32,7 @@ function validate_restore_count()
 
 function check_fast_boot ()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
     if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else

--- a/files/scripts/teamd.sh
+++ b/files/scripts/teamd.sh
@@ -32,8 +32,8 @@ function validate_restore_count()
 
 function check_fast_boot ()
 {
-    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
-    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB hget "FAST_RESTART_ENABLE_TABLE|system" enable`
+    if [[ x"${SYSTEM_FAST_REBOOT}" == x"true" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"

--- a/files/scripts/teamd.sh
+++ b/files/scripts/teamd.sh
@@ -32,7 +32,8 @@ function validate_restore_count()
 
 function check_fast_boot ()
 {
-    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_REBOOT|system"`
+    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -669,14 +669,15 @@ def is_warm_restart_enabled(container_name):
 
 # Check if System fast reboot is enabled.
 def is_fast_reboot_enabled():
-    fb_system_state = 0
-    cmd = 'sonic-db-cli STATE_DB get "FAST_REBOOT|system"'
-    proc = subprocess.Popen(cmd, shell=True, universal_newlines=True, stdout=subprocess.PIPE)
-    (stdout, stderr) = proc.communicate()
+    state_db = SonicV2Connector(host='127.0.0.1')
+    state_db.connect(state_db.STATE_DB, False)
 
-    if proc.returncode != 0:
-        log.log_error("Error running command '{}'".format(cmd))
-    elif stdout:
-        fb_system_state = stdout.rstrip('\n')
+    TABLE_NAME_SEPARATOR = '|'
+    prefix = 'FAST_REBOOT' + TABLE_NAME_SEPARATOR
 
-    return fb_system_state
+    _hash = '{}{}'.format(prefix, 'system')
+    fb_system_state = state_db.get(state_db.STATE_DB, _hash, "enable")
+    fb_enable_state = True if fb_system_state == "true" else False
+    
+    state_db.close(state_db.STATE_DB)
+    return fb_enable_state

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -669,14 +669,16 @@ def is_warm_restart_enabled(container_name):
 
 # Check if System fast reboot is enabled.
 def is_fast_reboot_enabled():
-    fb_system_state = 0
-    cmd = ['sonic-db-cli', 'STATE_DB', 'get', "FAST_REBOOT|system"]
-    proc = subprocess.Popen(cmd, universal_newlines=True, stdout=subprocess.PIPE)
-    (stdout, stderr) = proc.communicate()
-    if proc.returncode != 0:
-        log.log_error("Error running command '{}'".format(cmd))
-    elif stdout:
-        fb_system_state = stdout.rstrip('\n')
+    state_db = SonicV2Connector(host='127.0.0.1')
+    state_db.connect(state_db.STATE_DB, False)
+    
+    TABLE_NAME_SEPARATOR = '|'
+    prefix = 'FAST_RESTART_ENABLE_TABLE' + TABLE_NAME_SEPARATOR
+    
+    # Get the system warm reboot enable state
+    _hash = '{}{}'.format(prefix, 'system')
+    fb_system_state = state_db.get(state_db.STATE_DB, _hash, "enable")
+    fb_enable_state = True if fb_system_state == "true" else False
 
-    fb_system_state = True if fb_system_state == "enable" else False
-    return fb_system_state
+    state_db.close(state_db.STATE_DB)
+    return fb_enable_state

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -669,15 +669,14 @@ def is_warm_restart_enabled(container_name):
 
 # Check if System fast reboot is enabled.
 def is_fast_reboot_enabled():
-    state_db = SonicV2Connector(host='127.0.0.1')
-    state_db.connect(state_db.STATE_DB, False)
+    fb_system_state = 0
+    cmd = ['sonic-db-cli', 'STATE_DB', 'get', "FAST_REBOOT|system"]
+    proc = subprocess.Popen(cmd, universal_newlines=True, stdout=subprocess.PIPE)
+    (stdout, stderr) = proc.communicate()
+    if proc.returncode != 0:
+        log.log_error("Error running command '{}'".format(cmd))
+    elif stdout:
+        fb_system_state = stdout.rstrip('\n')
 
-    TABLE_NAME_SEPARATOR = '|'
-    prefix = 'FAST_REBOOT' + TABLE_NAME_SEPARATOR
-
-    _hash = '{}{}'.format(prefix, 'system')
-    fb_system_state = state_db.get(state_db.STATE_DB, _hash, "enable")
-    fb_enable_state = True if fb_system_state == "true" else False
-    
-    state_db.close(state_db.STATE_DB)
-    return fb_enable_state
+    fb_system_state = True if fb_system_state == "enable" else False
+    return fb_system_state


### PR DESCRIPTION
This PR should come along with sonic-utilities PR is similar to 13484, dedicated to 202205 branch.



Why I did it
To solve an issue with upgrade with fast-reboot including FW upgrade which has been introduced since moving to fast-reboot over warm-reboot infrastructure.
As well, this introduces fast-reboot finalizing logic to determine fast-reboot is done.

How I did it
Added logic to finalize-warmboot script to handle fast-reboot as well, this makes sense as using fast-reboot over warm-reboot this script will be invoked. The script will clear fast-reboot entry from state-db instead of previous implementation that relied on timer. The timer could expire in some scenarios between fast-reboot finished causing fallback to cold-reboot and possible crashes.

As well this PR updates all services/scripts reading fast-reboot state-db entry to look for the updated value representing fast-reboot is active.

How to verify it
Run fast-reboot and check that fast-reboot entry exists in state-db right after startup and being cleared as warm-reboot is finalized and not due to a timer.

