### PR TITLE
Finalize fast-reboot in warmboot finalizer

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -244,8 +244,7 @@ function postStartAction()
             fi
 
             if [[ "$BOOT_TYPE" == "fast" ]]; then
-                # set the key to expire in 3 minutes
-                $SONIC_DB_CLI STATE_DB SET "FAST_REBOOT|system" "1" "EX" "180"
+                $SONIC_DB_CLI STATE_DB SET "FAST_RESTART_ENABLE_TABLE|system" "enable"
             fi
 
             $SONIC_DB_CLI CONFIG_DB SET "CONFIG_DB_INITIALIZED" "1"

--- a/files/image_config/ntp/ntp-config.sh
+++ b/files/image_config/ntp/ntp-config.sh
@@ -8,11 +8,11 @@ reboot_type='cold'
 function get_database_reboot_type()
 {
     SYSTEM_WARM_START=`sonic-db-cli STATE_DB hget "WARM_RESTART_ENABLE_TABLE|system" enable`
-    SYSTEM_FAST_START=`sonic-db-cli STATE_DB get "FAST_REBOOT|system"`
+    SYSTEM_FAST_START=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
 
     if [[ x"${SYSTEM_WARM_START}" == x"true" ]]; then
         reboot_type='warm'
-    elif [[ x"${SYSTEM_FAST_START}" == x"1" ]]; then
+    elif [[ x"${SYSTEM_FAST_START}" == x"enable" ]]; then
         reboot_type='fast'
     fi
 }

--- a/files/scripts/bgp.sh
+++ b/files/scripts/bgp.sh
@@ -30,7 +30,8 @@ function validate_restore_count()
 
 function check_fast_boot ()
 {
-    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
+    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"

--- a/files/scripts/service_mgmt.sh
+++ b/files/scripts/service_mgmt.sh
@@ -19,7 +19,8 @@ function check_warm_boot()
 
 function check_fast_boot ()
 {
-    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
+    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"

--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -60,7 +60,8 @@ function check_warm_boot()
 
 function check_fast_boot()
 {
-    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
+    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"
@@ -284,8 +285,8 @@ stop() {
     # encountered error, e.g. syncd crashed. And swss needs to
     # be restarted.
     if [[ x"$FAST_BOOT" != x"true" ]]; then
-        debug "Clearing FAST_REBOOT flag..."
-        clean_up_tables STATE_DB "'FAST_REBOOT*'"
+        debug "Clearing FAST_RESTART_ENABLE_TABLE flag..."
+        sonic-db-cli STATE_DB SET "FAST_RESTART_ENABLE_TABLE|system" "disable"
     fi
     # Unlock has to happen before reaching out to peer service
     unlock_service_state_change

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -50,7 +50,8 @@ function check_warm_boot()
 
 function check_fast_boot()
 {
-    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
+    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"
@@ -82,7 +83,8 @@ function getBootType()
         ;;
     *SONIC_BOOT_TYPE=fast*|*fast-reboot*)
         # check that the key exists
-        if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+        SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
+        if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
             TYPE='fast'
         else
             TYPE='cold'

--- a/files/scripts/teamd.sh
+++ b/files/scripts/teamd.sh
@@ -32,7 +32,8 @@ function validate_restore_count()
 
 function check_fast_boot ()
 {
-    if [[ $($SONIC_DB_CLI STATE_DB GET "FAST_REBOOT|system") == "1" ]]; then
+    SYSTEM_FAST_REBOOT=`sonic-db-cli STATE_DB GET "FAST_RESTART_ENABLE_TABLE|system"`
+    if [[ ${SYSTEM_FAST_REBOOT} == "enable" ]]; then
         FAST_BOOT="true"
     else
         FAST_BOOT="false"

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -709,4 +709,5 @@ def is_fast_reboot_enabled():
     elif stdout:
         fb_system_state = stdout.rstrip('\n')
 
+    fb_system_state = True if fb_system_state == "enable" else False
     return fb_system_state


### PR DESCRIPTION
This PR should come along with sonic-utilities PR is similar to 13484, dedicated to 202211 branch.

Why I did it
To solve an issue with upgrade with fast-reboot including FW upgrade which has been introduced since moving to fast-reboot over warm-reboot infrastructure.
As well, this introduces fast-reboot finalizing logic to determine fast-reboot is done.

How I did it
Added logic to finalize-warmboot script to handle fast-reboot as well, this makes sense as using fast-reboot over warm-reboot this script will be invoked. The script will clear fast-reboot entry from state-db instead of previous implementation that relied on timer. The timer could expire in some scenarios between fast-reboot finished causing fallback to cold-reboot and possible crashes.

As well this PR updates all services/scripts reading fast-reboot state-db entry to look for the updated value representing fast-reboot is active.

How to verify it
Run fast-reboot and check that fast-reboot entry exists in state-db right after startup and being cleared as warm-reboot is finalized and not due to a timer.