### PR TITLE
[Mellanox] Update the method of reading model number for MLNX platforms

### DIFF
--- a/files/build/versions/dockers/docker-syncd-mlnx/versions-deb-bookworm
+++ b/files/build/versions/dockers/docker-syncd-mlnx/versions-deb-bookworm
@@ -5,8 +5,8 @@ gdbserver==13.1-3
 iproute2-mlnx==6.1.0-3
 libbabeltrace1==1.5.11-1+b2
 libboost-regex1.74.0==1.74.0+ds1-21
-libc-dev-bin==2.36-9+deb12u7
-libc6-dev==2.36-9+deb12u7
+libc-dev-bin==2.36-9+deb12u9
+libc6-dev==2.36-9+deb12u9
 libcbor0.8==0.8.0-2+b1
 libcurl3-gnutls==7.88.1-10+deb12u8
 libdebuginfod-common==0.188-2.1

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -27,6 +27,8 @@ try:
     from sonic_platform_base.chassis_base import ChassisBase
     from sonic_py_common.logger import Logger
     import os
+    import subprocess
+    from sonic_py_common import device_info
     from functools import reduce
     from .utils import extract_RJ45_ports_index
     from . import module_host_mgmt_initializer
@@ -56,6 +58,9 @@ REBOOT_CAUSE_READY_FILE = '/run/hw-management/config/reset_attr_ready'
 REBOOT_TYPE_KEXEC_FILE = "/proc/cmdline"
 REBOOT_TYPE_KEXEC_PATTERN_WARM = ".*SONIC_BOOT_TYPE=(warm|fastfast).*"
 REBOOT_TYPE_KEXEC_PATTERN_FAST = ".*SONIC_BOOT_TYPE=(fast|fast-reboot).*"
+
+SPC_RETRIEVAL = "lspci | grep 'Mellanox Technologies'"
+SYS_DISPLAY = "SYS_DISPLAY"
 
 # Global logger class instance
 logger = Logger()
@@ -327,7 +332,7 @@ class Chassis(ChassisBase):
         Returns:
             A list of objects derived from SfpBase representing all sfps
             available on this chassis
-        """    
+        """
         if DeviceDataManager.is_module_host_management_mode():
             self.module_host_mgmt_initializer.initialize(self)
         else:
@@ -407,7 +412,7 @@ class Chassis(ChassisBase):
         else:
             self.initialize_sfp()
             return self.get_change_event_legacy(timeout)
-            
+
     def get_change_event_for_module_host_management_mode(self, timeout):
         """Get SFP change event when module host management mode is enabled.
 
@@ -439,9 +444,9 @@ class Chassis(ChassisBase):
                     self.registered_fds[fd.fileno()] = (s.sdk_index, fd, fd_type)
 
             logger.log_debug(f'Registered SFP file descriptors for polling: {self.registered_fds}')
-                    
+
         from . import sfp
-        
+
         wait_forever = (timeout == 0)
         # poll timeout should be no more than 1000ms to ensure fast shutdown flow
         timeout = 1000.0 if timeout >= 1000 else float(timeout)
@@ -449,14 +454,14 @@ class Chassis(ChassisBase):
         error_dict = {}
         begin = time.monotonic()
         wait_ready_task = sfp.SFP.get_wait_ready_task()
-        
-        while True:        
+
+        while True:
             fds_events = self.poll_obj.poll(timeout)
             for fileno, _ in fds_events:
                 if fileno not in self.registered_fds:
                     logger.log_error(f'Unknown file no {fileno} from poll event, registered files are {self.registered_fds}')
                     continue
-                
+
                 sfp_index, fd, fd_type = self.registered_fds[fileno]
                 s = self._sfp_list[sfp_index]
                 fd.seek(0)
@@ -480,7 +485,7 @@ class Chassis(ChassisBase):
                         # FW control cable got an error, no need trigger state machine
                         sfp_status, error_desc = s.get_error_info_from_sdk_error_type()
                         port_dict[sfp_index + 1] = sfp_status
-                        if error_desc: 
+                        if error_desc:
                             error_dict[sfp_index + 1] = error_desc
                         continue
                     elif str(fd_value) == sfp.SFP_STATUS_INSERTED:
@@ -496,14 +501,14 @@ class Chassis(ChassisBase):
                     # event could be EVENT_POWER_GOOD or EVENT_POWER_BAD
                     event = sfp.EVENT_POWER_BAD if fd_value == 0 else sfp.EVENT_POWER_GOOD
                     s.on_event(event)
-                    
+
                 if s.in_stable_state():
                     self.sfp_module.SFP.wait_sfp_eeprom_ready([s], 2)
                     s.fill_change_event(port_dict)
                     s.refresh_poll_obj(self.poll_obj, self.registered_fds)
                 else:
                     logger.log_debug(f'SFP {sfp_index} does not reach stable state, state={s.state}')
-                    
+
             ready_sfp_set = wait_ready_task.get_ready_set()
             for sfp_index in ready_sfp_set:
                 s = self._sfp_list[sfp_index]
@@ -514,7 +519,7 @@ class Chassis(ChassisBase):
                     s.refresh_poll_obj(self.poll_obj, self.registered_fds)
                 else:
                     logger.log_error(f'SFP {sfp_index} failed to reach stable state, state={s.state}')
-                    
+
             if port_dict:
                 logger.log_notice(f'Sending SFP change event: {port_dict}, error event: {error_dict}')
                 self.reinit_sfps(port_dict)
@@ -561,23 +566,23 @@ class Chassis(ChassisBase):
                 self.sfp_states_before_first_poll[s.sdk_index] = s.get_module_status()
 
             logger.log_debug(f'Registered SFP file descriptors for polling: {self.registered_fds}')
-            
+
         from . import sfp
-        
+
         wait_forever = (timeout == 0)
         # poll timeout should be no more than 1000ms to ensure fast shutdown flow
         timeout = 1000.0 if timeout >= 1000 else float(timeout)
         port_dict = {}
         error_dict = {}
         begin = time.monotonic()
-        
+
         while True:
             fds_events = self.poll_obj.poll(timeout)
             for fileno, _ in fds_events:
                 if fileno not in self.registered_fds:
                     logger.log_error(f'Unknown file no {fileno} from poll event, registered files are {self.registered_fds}')
                     continue
-                
+
                 sfp_index, fd = self.registered_fds[fileno]
                 fd.seek(0)
                 fd.read()
@@ -742,8 +747,15 @@ class Chassis(ChassisBase):
         Returns:
             string: Model/part number of device
         """
-        self.initialize_eeprom()
-        return self._eeprom.get_part_number()
+        model = None
+        if self._read_from_vpd:
+            if not self.vpd_data:
+                self.vpd_data = self._parse_vpd_data(VPD_DATA_FILE)
+            model = self.vpd_data.get(SYS_DISPLAY, "N/A")
+        else:
+            self.initialize_eeprom()
+            model = self._eeprom.get_part_number()
+        return model
 
     def get_base_mac(self):
         """
@@ -938,11 +950,23 @@ class Chassis(ChassisBase):
                 return result
 
             result = utils.read_key_value_file(filename, delimeter=": ")
-                
+
         except Exception as e:
             logger.log_error("Fail to decode vpd_data {} due to {}".format(filename, repr(e)))
 
         return result
+
+    def _get_spectrum_revision(self):
+        p = subprocess.Popen(SPC_RETRIEVAL, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = p.communicate()
+        spc_revision = re.search('Spectrum-[1-9]{1}', out)
+        if spc_revision is None:
+            spc_revision = 1
+        return int(spc_revision)
+
+    def _read_from_vpd(self):
+        spc_revision = self._get_spectrum_revision()
+        return (spc_revision >= 4)
 
     def _verify_reboot_cause(self, filename):
         '''

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -747,7 +747,7 @@ class Chassis(ChassisBase):
             string: Model/part number of device
         """
         model = None
-        if self._read_from_vpd():
+        if self._read_model_from_vpd():
             if not self.vpd_data:
                 self.vpd_data = self._parse_vpd_data(VPD_DATA_FILE)
             model = self.vpd_data.get(SYS_DISPLAY, "N/A")
@@ -955,17 +955,29 @@ class Chassis(ChassisBase):
 
         return result
 
-    def _get_spectrum_revision(self):
+    def _get_spectrum_version(self):
+        """
+        Returns spectrum version of the platform
+
+        Returns:
+            Returns spectrum version of the platform
+        """
         out = check_output(SPC_RETRIEVAL, shell=True)
-        spc_revision = 1
+        spc_version = 1
         spc_match = re.search('Spectrum-([1-9](?!\d))', out.decode("utf-8"))
         if spc_match is not None:
-            spc_revision = int(spc_match.group(1))
-        return spc_revision
+            spc_version = int(spc_match.group(1))
+        return spc_version
 
-    def _read_from_vpd(self):
-        spc_revision = self._get_spectrum_revision()
-        return (spc_revision >= 4)
+    def _read_model_from_vpd(self):
+        """
+        Returns if model number should be returned from VPD file
+
+        Returns:
+            Returns True if spectrum version is higher than Spectrum-4
+        """
+        spc_version = self._get_spectrum_version()
+        return (spc_version >= 4)
 
     def _verify_reboot_cause(self, filename):
         '''

--- a/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2021-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
@@ -34,7 +34,7 @@ from sonic_platform.eeprom import Eeprom, EepromContentVisitor
 class TestEeprom:
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.islink', MagicMock(return_value=True))
-    @patch('sonic_platform.chassis._read_from_vpd', MagicMock(return_value=False))
+    @patch('sonic_platform.chassis.Chassis._read_from_vpd', MagicMock(return_value=False))
     @patch('sonic_platform.eeprom.Eeprom.get_system_eeprom_info')
     @patch('sonic_platform.chassis.extract_RJ45_ports_index', MagicMock(return_value=[]))
     def test_chassis_eeprom(self, mock_eeprom_info):

--- a/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
@@ -34,7 +34,8 @@ from sonic_platform.eeprom import Eeprom, EepromContentVisitor
 class TestEeprom:
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.islink', MagicMock(return_value=True))
-    @patch('sonic_platform.chassis.Chassis._read_model_from_vpd', MagicMock(return_value=False))
+    @patch('sonic_platform.chassis.Chassis.check_output',
+           MagicMock(return_value="Ethernet controller: Mellanox Technologies MT53100 [Spectrum-2]"))
     @patch('sonic_platform.eeprom.Eeprom.get_system_eeprom_info')
     @patch('sonic_platform.chassis.extract_RJ45_ports_index', MagicMock(return_value=[]))
     def test_chassis_eeprom(self, mock_eeprom_info):

--- a/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
@@ -34,8 +34,8 @@ from sonic_platform.eeprom import Eeprom, EepromContentVisitor
 class TestEeprom:
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.islink', MagicMock(return_value=True))
-    @patch('sonic_platform.chassis.Chassis.check_output',
-           MagicMock(return_value="Ethernet controller: Mellanox Technologies MT53100 [Spectrum-2]"))
+    @patch('sonic_platform.chassis.check_output',
+           MagicMock(return_value=b'Ethernet controller: Mellanox Technologies MT53100 [Spectrum-2]'))
     @patch('sonic_platform.eeprom.Eeprom.get_system_eeprom_info')
     @patch('sonic_platform.chassis.extract_RJ45_ports_index', MagicMock(return_value=[]))
     def test_chassis_eeprom(self, mock_eeprom_info):

--- a/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
@@ -34,7 +34,7 @@ from sonic_platform.eeprom import Eeprom, EepromContentVisitor
 class TestEeprom:
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.islink', MagicMock(return_value=True))
-    @patch('sonic_platform.chassis.Chassis._read_from_vpd', MagicMock(return_value=False))
+    @patch('sonic_platform.chassis.Chassis._read_model_from_vpd', MagicMock(return_value=False))
     @patch('sonic_platform.eeprom.Eeprom.get_system_eeprom_info')
     @patch('sonic_platform.chassis.extract_RJ45_ports_index', MagicMock(return_value=[]))
     def test_chassis_eeprom(self, mock_eeprom_info):

--- a/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_eeprom.py
@@ -33,6 +33,7 @@ from sonic_platform.eeprom import Eeprom, EepromContentVisitor
 class TestEeprom:
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.islink', MagicMock(return_value=True))
+    @patch('sonic_platform.chassis._read_from_vpd', MagicMock(return_value=False))
     @patch('sonic_platform.eeprom.Eeprom.get_system_eeprom_info')
     @patch('sonic_platform.chassis.extract_RJ45_ports_index', MagicMock(return_value=[]))
     def test_chassis_eeprom(self, mock_eeprom_info):
@@ -73,7 +74,7 @@ class TestEeprom:
             return return_values.get((key, field))
         eeprom = Eeprom()
         eeprom._redis_hget = MagicMock(side_effect = side_effect)
-        
+
         info = eeprom.get_system_eeprom_info()
         assert eeprom.get_product_name() == 'MSN3420'
         assert eeprom.get_part_number() == 'MSN3420-CB2FO'
@@ -84,7 +85,7 @@ class TestEeprom:
 
     @patch('os.path.exists', MagicMock(return_value=True))
     @patch('os.path.islink', MagicMock(return_value=True))
-    def test_get_system_eeprom_info_from_hardware(self):    
+    def test_get_system_eeprom_info_from_hardware(self):
         eeprom = Eeprom()
         eeprom.p = os.path.join(test_path, 'mock_eeprom_data')
         eeprom._redis_hget = MagicMock()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To return the correct Model Number for MLNX platforms rather than Part Number.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
For SPC1-3 read it from eeprom.part_number and for SPC4 and newer read it from VPD file, SYS_DISPLAY value.
#### How to verify it
Manual testing: 'show platform summary' for each spectrum.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

